### PR TITLE
fix for gas_estimation using rpc

### DIFF
--- a/kuru_sdk_py/transaction/transaction.py
+++ b/kuru_sdk_py/transaction/transaction.py
@@ -131,11 +131,12 @@ class AsyncTransactionSenderMixin:
                         total_storage_slots = sum(
                             len(entry.get("storageKeys", [])) for entry in access_list
                         )
+                        effective_storage_slots = int(total_storage_slots * 0.6)
                         # Use config for gas adjustment
                         adjusted_gas = estimated_gas - (
-                            total_storage_slots
+                            effective_storage_slots
                             * self.transaction_config.gas_adjustment_per_slot
-                        ) + self.transaction_config.gas_buffer
+                        )
                         final_gas = int(
                             adjusted_gas
                             * self.transaction_config.gas_buffer_multiplier


### PR DESCRIPTION
Updated gas adjustment for access-list transactions to assume only 60% of storage slots are effectively used, and removed the `DEFAULT_GAS_BUFFER` add-on from this path while keeping multiplier-based final gas scaling.